### PR TITLE
Fix and improve farm command output

### DIFF
--- a/src/commands/farm.ts
+++ b/src/commands/farm.ts
@@ -31,12 +31,17 @@ async function asyncHandler(
 	if (results === undefined) {
 		sendAndCache(message, `Sorry, I couldn't find an item matching '${searchString}'`);
 	} else if (results.length > 1) {
-		sendAndCache(
-			message,
-			`There are ${results.length} items matching that: ${results
-				.map(item => item.name)
-				.join(', ')}. Which one did you mean?`
-		);
+		sendAndCache(message, `There are ${results.length} items matching that. Which one did you mean?`);
+		results.forEach((item) => {
+			let shortSymbol = item.symbol.replace(/_quality.*/, '');
+			let embed = new RichEmbed()
+				.setTitle(item.name)
+				.setDescription(`\`${shortSymbol}\``)
+				.setThumbnail(`${CONFIG.ASSETS_URL}${item.imageUrl}`)
+				.setColor(colorFromRarity(item.rarity))
+				.setURL(`${CONFIG.DATACORE_URL}item_info?symbol=${item.symbol}`);
+			sendAndCache(message, embed);
+		});
 	} else {
 		let item = results[0];
 

--- a/src/data/DCData.ts
+++ b/src/data/DCData.ts
@@ -246,12 +246,20 @@ class DCDataClass {
 			keys: ['name']
 		};
 
-		// Try a plain substring search first in case we get an exact match
-		let found = this._items.filter(
+		// Try a plain search on name in case we get an exact match
+		let foundByName = this._items.filter(
 			item => item.name.toLowerCase() === searchString.toLowerCase() && item.rarity === rarity
 		);
-		if (found && found.length === 1) {
-			return found;
+		if (foundByName && foundByName.length === 1) {
+			return foundByName;
+		}
+
+		// Try a plain substring search on symbol in case we get an exact match
+		let foundBySymbol = this._items.filter(
+			item => item.symbol.toLowerCase().includes(searchString.toLowerCase()) && item.rarity === rarity
+		);
+		if (foundBySymbol && foundBySymbol.length === 1) {
+			return foundBySymbol;
 		}
 
 		const fuse = new Fuse(
@@ -259,8 +267,6 @@ class DCDataClass {
 			options
 		);
 		const results = fuse.search(searchString) as any[];
-
-		//console.log(results.map((i: any) => ({score: i.score, name: i.item.name})));
 
 		// No matches
 		if (results.length === 0) {
@@ -272,14 +278,7 @@ class DCDataClass {
 			return [results[0].item];
 		}
 
-		// An exact match
-		if (results[0].score < 0.01) {
-			return results.filter(r => r.score < 0.01).map(r => r.item);
-		}
-
-		// Multiple results, none are exact
-		//return results.map(r => r.item);
-		return [results[0].item];
+		return results.map(r => r.item);
 	}
 }
 


### PR DESCRIPTION
Fixes https://github.com/stt-datacore/website/issues/28.

It turns out the current logic is very weird, and essentially returns multiple matches, unless the matching was too low, in which case it randomly returns the first match.

Which means that a search for `hyperspanner` returns the list of two hyperspanners, but a search for `hyperspanner ds9` randomly shows one (which in this case is a 50-50 chance to be the one you want).

This pull request:

- Fixes the logic bug mentioned above
- Implements a better output when multiple items match search criteria, using Discord embeds to visually show the matching items (and link through to DataCore)
- Adds a shortened version of the unique `symbol` field to the multiple field output (shortened to remove the quality suffix, as we already specify quality in the command), allowing the user to select a specific item from multiple items with the same name/quality.

![image](https://user-images.githubusercontent.com/834880/104107853-e9fba800-5313-11eb-8d22-73349da9b0ab.png)

This does take up a bit more space, especially for searches like `rare padd` which has 9 results, but showing the images (and links) gives users a much better chance to identify the correct item.