### PR TITLE
Deprecate Big Book, add CAB

### DIFF
--- a/src/commands/stats.ts
+++ b/src/commands/stats.ts
@@ -118,7 +118,11 @@ async function asyncHandler(message: Message, searchString: string, raritySearch
 			.setFooter(formatCrewCoolRanks(crew));
 
 		if (crew.bigbook_tier && crew.events) {
-			embed = embed.addField('Bigbook Tier', crew.bigbook_tier === -1 ? '¯\\_(ツ)_/¯' : crew.bigbook_tier, true).addField('Events', crew.events, true);
+			embed = embed.addField('Bigbook Tier (Legacy)', crew.bigbook_tier === -1 ? '¯\\_(ツ)_/¯' : crew.bigbook_tier, true).addField('Events', crew.events, true);
+		}
+
+		if (crew.cab_ov) {
+			embed = embed.addField('CAB Rating', `[${crew.cab_ov}](https://sttpowerratings.com/)`, true);
 		}
 
 		if (crew.collections && crew.collections.length > 0) {
@@ -153,7 +157,7 @@ async function asyncHandler(message: Message, searchString: string, raritySearch
 		}
 
 		if (extended && crew.markdownContent && crew.markdownContent.length < 980) {
-			embed = embed.addField('Book contents', crew.markdownContent);
+			embed = embed.addField('Book contents (legacy)', crew.markdownContent);
 		}
 
 		sendAndCache(message, embed);
@@ -161,7 +165,7 @@ async function asyncHandler(message: Message, searchString: string, raritySearch
 		if (extended && crew.markdownContent && crew.markdownContent.length >= 980) {
 			if (crew.markdownContent.length < 2048) {
 				let embed = new RichEmbed()
-					.setTitle(`Big book details for ${crew.name}`)
+					.setTitle(`Big book details for ${crew.name} (legacy)`)
 					.setColor(colorFromRarity(crew.max_rarity))
 					.setURL(`${CONFIG.DATACORE_URL}crew/${crew.symbol}/`)
 					.setDescription(crew.markdownContent);

--- a/src/utils/beholdcalc.ts
+++ b/src/utils/beholdcalc.ts
@@ -40,7 +40,7 @@ export function isValidBehold(data: any, threshold: number = 10) {
 export function formatCrewField(message: Message, crew: Definitions.BotCrew, stars: number, custom: string) {
 	let reply = '';
 	if (crew.bigbook_tier) {
-		reply += `Big book **tier ${crew.bigbook_tier}**, `;
+		reply += `Big book **tier ${crew.bigbook_tier}** (Legacy), `;
 	}
 
 	reply += `Voyage #${crew.ranks.voyRank}, Gauntlet #${crew.ranks.gauntletRank}, ${crew.events || 0} event${
@@ -68,6 +68,7 @@ interface CrewFromBehold {
 
 function recommendations(crew: CrewFromBehold[]) {
 	let best = crew.sort((a, b) => a.crew.bigbook_tier - b.crew.bigbook_tier);
+	let bestCab = crew.sort((a, b) => parseFloat(b.crew.cab_ov) - parseFloat(a.crew.cab_ov));
 	let starBest = crew.filter(c => c.stars > 0 && c.stars < c.crew.max_rarity);
 
 	if (starBest.length > 0) {
@@ -116,6 +117,10 @@ function recommendations(crew: CrewFromBehold[]) {
 				}
 			}
 		}
+	}
+	if (best[0] !== bestCab[0]) {
+		title = `Big Book Recommendation (Legacy): ${title}
+		CAB Power Ratings Recommendation: ${bestCab[0].crew.name}`
 	}
 
 	return {

--- a/src/utils/definitions.d.ts
+++ b/src/utils/definitions.d.ts
@@ -150,6 +150,7 @@ declare namespace Definitions {
 		craftCost: number;
 		max_rarity: number;
 		bigbook_tier: number;
+		cab_ov: string;
 		events: number;
 		ranks: BotCrewRanks;
 		base_skills: Skills;


### PR DESCRIPTION
- Mark Big Book info as legacy
- Show CAB overall power rating in stats
- When recommendation based on CAB rating differs from Big Book, provide user with both recommendations